### PR TITLE
Fixing duplicate method names in OOPCourse class

### DIFF
--- a/compulsory_task_1.py
+++ b/compulsory_task_1.py
@@ -17,9 +17,6 @@ class OOPCourse(Course):
         print(f"The course is about {self.description} and is presented by {self.trainer}.")
 
     def show_course_id(self):
-        print(f"The course is about {self.description} and is presented by {self.trainer}.")
-
-    def show_course_id(self):
         print("The course ID is #12345")
 
 


### PR DESCRIPTION
Removed duplicate show_course_id method in the 'OOPCourse' class to ensure correct functionality.